### PR TITLE
Added Access-Control headers if CORS is enabled

### DIFF
--- a/o.js
+++ b/o.js
@@ -1509,6 +1509,7 @@
             }
 
             if (base.oConfig.isCors && 'withCredentials' in xhr) {
+				xhr.withCredentials=true;
                 // XHR for Chrome/Firefox/Opera/Safari.
                 xhr.open(method, url, base.oConfig.isAsync);
             }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "o.js",
   "description": "o.js is a client side Odata Javascript library to simplify the request of data. The main goal is to build a standalone, lightweight and easy to understand Odata lib.",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "main": "o.js",
   "dependencies": {
     "q": "^1.5.0",


### PR DESCRIPTION
First PR here, let's hope I do it well :)

Without setting withCredentials to true on javascript XHR, CORS is disabled. I added that in the relevant part of the code.

But there is something strange as 
- the containing "if" part already refers to the "withCredential" field 
- Another part of the code already reference this, but in a commented line

By reading the code, I suspect that maybe the developer knew but removed references to withCredential for a purpose. Maybe I am missing something here but the MDN article on withCredential does not indicate any side-effect.

https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials