### PR TITLE
Fix ID property missing last character when using `.ref` and `.removeRef`

### DIFF
--- a/o.js
+++ b/o.js
@@ -411,7 +411,7 @@
             var newResource = parseUri(navPath);
             newResource.path[newResource.path.length - 1].get = id;
             var baseRes = buildQuery(newResource);
-            resource.data = { '@odata.id': baseRes.substring(0, baseRes.length - 1) };
+            resource.data = { '@odata.id': baseRes };
             return (base);
         }
 
@@ -437,7 +437,7 @@
                 var newResource = parseUri(navPath);
                 newResource.path[newResource.path.length - 1].get = id;
                 var baseRes = buildQuery(newResource);
-                addQuery('$id', baseRes.substring(0, baseRes.length - 1));
+                addQuery('$id', baseRes);
             }
             //set the method
             resource.method = 'DELETE';


### PR DESCRIPTION
After the fix to remove trailing slashes, the `.ref` and  `.removeRef` methods still removes the last character.

This results in URLs looking like this:
`http://services.odata.org/v4/TripPinServiceRW/People('myusername')/$ref?$id=http://services.odata.org/v4/TripPinServiceRW/People('otherusername'`

This PR simply removes the `.substring` call when adding the resource ID to the request.

Let me know if you want this fixed some other way. Considering #60, this might not be a permanent fix anyway.