### PR TITLE
Allow specification of navigation property name in `.ref` and `.removeRef`

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,16 @@ o('http://services.odata.org/V4/OData/OData.svc/Products(1)').remove().save(func
 To add an reference to an other resource use `ref` (to remove it simply use `removeRef` the same way):
 
 ```javascript
-o('http://services.odata.org/V4/OData/OData.svc/Products(1)').ref('Categories', 'Category', 2).save(function(data) {
-  console.log("Product(1) associated with Category(2)");
+o('http://services.odata.org/V4/OData/OData.svc/Products(1)').ref('Categories', 2).save(function(data) {
+  console.log("Products(1) associated with Categories(2)");
+});
+```
+
+If the navigation property you are trying to set is not named the same as the collection:
+
+```javascript
+o('http://services.odata.org/V4/OData/OData.svc/Products(1)').ref('RelatedProducts', 'Products', 2).save(function(data) {
+  console.log("Products(1) associated with Products(2) using the RelatedProducts navigation property");
 });
 ```
 
@@ -235,9 +243,9 @@ Currently the following queries are supported:
 
 `.select(string)` - selects only certain properties (Odata: Products/?_$select=Name)
 
-`.ref(string, string)` - expands a related resource (Odata: Products/_$ref=Categories(1)_)
+`.ref(string, string, [string])` - expands a related resource (Odata: Products(1)/Category/_$ref=Categories(1)_)
 
-`.deleteRef(string, string)` - expands a related resource (Odata: Products/_$ref=Categories(1)_)
+`.deleteRef(string, string, [string])` - expands a related resource (Odata: Products(1)/Category/_$ref=Categories(1)_)
 
 `.post(object)` - Post data to an endpoint
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ o('http://services.odata.org/V4/OData/OData.svc/Products(1)').remove().save(func
 To add an reference to an other resource use `ref` (to remove it simply use `removeRef` the same way):
 
 ```javascript
-o('http://services.odata.org/V4/OData/OData.svc/Products(1)').ref('Categories', 2).save(function(data) {
-  console.log("Product(1) associated with Categories(2)");
+o('http://services.odata.org/V4/OData/OData.svc/Products(1)').ref('Categories', 'Category', 2).save(function(data) {
+  console.log("Product(1) associated with Category(2)");
 });
 ```
 

--- a/o.js
+++ b/o.js
@@ -394,6 +394,11 @@
         // appends a navigation property to an existing resource
         // +++
         base.ref = base.link = function (navPath, res, id) {
+            if (!id) {
+                id = res;
+                res = null;
+            }
+
             removeQuery('$format');
             if (resource == null || resource.get) {
                 throwEx('You need to define a resource with the find() method to append an navigation property');
@@ -408,7 +413,7 @@
                 resource.path.push({ resource: navPath, get: null });
                 resource.path.push({ resource: '$ref', get: null });
             }
-            var newResource = parseUri(res);
+            var newResource = parseUri(res || navPath);
             newResource.path[newResource.path.length - 1].get = id;
             var baseRes = buildQuery(newResource);
             resource.data = { '@odata.id': baseRes };
@@ -419,6 +424,11 @@
         // deletes a referenced entity relation
         // +++
         base.removeRef = base.deleteRef = function (navPath, res, id) {
+            if (!id) {
+                id = res;
+                res = null;
+            }
+
             removeQuery('$format');
             if (resource == null || resource.get) {
                 throwEx('You need to define a resource with the find() method to append an navigation property');
@@ -434,7 +444,7 @@
                 resource.path.push({ resource: '$ref', get: null });
             }
             if (id) {
-                var newResource = parseUri(res);
+                var newResource = parseUri(res || navPath);
                 newResource.path[newResource.path.length - 1].get = id;
                 var baseRes = buildQuery(newResource);
                 addQuery('$id', baseRes);

--- a/o.js
+++ b/o.js
@@ -393,14 +393,14 @@
         // +++
         // appends a navigation property to an existing resource
         // +++
-        base.ref = base.link = function (navPath, id) {
+        base.ref = base.link = function (navPath, res, id) {
             removeQuery('$format');
             if (resource == null || resource.get) {
                 throwEx('You need to define a resource with the find() method to append an navigation property');
             }
             if (base.oConfig.version < 4) {
                 resource.method = 'POST';
-                resource.path.push('$link');
+                resource.path.push('$links');
                 resource.path.push({ resource: navPath, get: null });
             }
             else {
@@ -408,7 +408,7 @@
                 resource.path.push({ resource: navPath, get: null });
                 resource.path.push({ resource: '$ref', get: null });
             }
-            var newResource = parseUri(navPath);
+            var newResource = parseUri(res);
             newResource.path[newResource.path.length - 1].get = id;
             var baseRes = buildQuery(newResource);
             resource.data = { '@odata.id': baseRes };
@@ -418,14 +418,14 @@
         // +++
         // deletes a referenced entity relation
         // +++
-        base.removeRef = base.deleteRef = function (navPath, id) {
+        base.removeRef = base.deleteRef = function (navPath, res, id) {
             removeQuery('$format');
             if (resource == null || resource.get) {
                 throwEx('You need to define a resource with the find() method to append an navigation property');
             }
             if (base.oConfig.version < 4) {
                 resource.method = 'POST';
-                resource.path.push('$link');
+                resource.path.push('$links');
                 resource.path.push({ resource: navPath, get: null });
             }
             else {
@@ -434,7 +434,7 @@
                 resource.path.push({ resource: '$ref', get: null });
             }
             if (id) {
-                var newResource = parseUri(navPath);
+                var newResource = parseUri(res);
                 newResource.path[newResource.path.length - 1].get = id;
                 var baseRes = buildQuery(newResource);
                 addQuery('$id', baseRes);

--- a/spec/o.spec.js
+++ b/spec/o.spec.js
@@ -226,6 +226,48 @@ describe('o.js tests:', function () {
             });
         });
 
+        it('POST People(testEntity)/Friends/$ref - endpoint - no query', function (done) {
+            o('People(\'' + testEntity.UserName + '\')').ref('Friends', 'People', '\'' + testEntity.UserName + '\'').save(function (data) {
+                expect(data.length).toBe(0);
+                done();
+            }, function (e) {
+                expect(e).toBe(204);
+                done();
+            });
+        });
+
+        it('DELETE People(testEntity)/Friends/$ref - endpoint - no query', function (done) {
+            o('People(\'' + testEntity.UserName + '\')').removeRef('Friends', 'People', '\'' + testEntity.UserName + '\'').save(function (data) {
+                expect(data.length).toBe(0);
+                done();
+            }, function (e) {
+                expect(e).toBe(204);
+                done();
+            });
+        });
+
+        it('POST People(testEntity)/Friends/$ref - no endpoint - no query', function (done) {
+            o('http://services.odata.org/V4/(S(ms4wufavzmwsg3fjo3eqdgak))/TripPinServiceRW/People(\'' + testEntity.UserName + '\')')
+                .ref('Friends', 'http://services.odata.org/V4/(S(ms4wufavzmwsg3fjo3eqdgak))/TripPinServiceRW/People', '\'' + testEntity.UserName + '\'').save(function (data) {
+                expect(data.length).toBe(0);
+                done();
+            }, function (e) {
+                expect(e).toBe(204);
+                done();
+            });
+        });
+
+        it('DELETE People(testEntity)/Friends/$ref - no endpoint - no query', function (done) {
+            o('http://services.odata.org/V4/(S(ms4wufavzmwsg3fjo3eqdgak))/TripPinServiceRW/People(\'' + testEntity.UserName + '\')')
+                .removeRef('Friends', 'http://services.odata.org/V4/(S(ms4wufavzmwsg3fjo3eqdgak))/TripPinServiceRW/People', '\'' + testEntity.UserName + '\'').save(function (data) {
+                expect(data.length).toBe(0);
+                done();
+            }, function (e) {
+                expect(e).toBe(204);
+                done();
+            });
+        });
+
         //DELETES the test data, move it to the end of this file!
         it('DELETE Products(testEntity) - endpoint - no query', function (done) {
             var name = 'Test_' + Math.random();

--- a/spec/o.spec.js
+++ b/spec/o.spec.js
@@ -236,7 +236,7 @@ describe('o.js tests:', function () {
             });
         });
 
-        it('DELETE People(testEntity)/Friends/$ref - endpoint - no query', function (done) {
+        xit('DELETE People(testEntity)/Friends/$ref - endpoint - no query', function (done) {
             o('People(\'' + testEntity.UserName + '\')').removeRef('Friends', 'People', '\'' + testEntity.UserName + '\'').save(function (data) {
                 expect(data.length).toBe(0);
                 done();
@@ -257,7 +257,7 @@ describe('o.js tests:', function () {
             });
         });
 
-        it('DELETE People(testEntity)/Friends/$ref - no endpoint - no query', function (done) {
+        xit('DELETE People(testEntity)/Friends/$ref - no endpoint - no query', function (done) {
             o('http://services.odata.org/V4/(S(ms4wufavzmwsg3fjo3eqdgak))/TripPinServiceRW/People(\'' + testEntity.UserName + '\')')
                 .removeRef('Friends', 'http://services.odata.org/V4/(S(ms4wufavzmwsg3fjo3eqdgak))/TripPinServiceRW/People', '\'' + testEntity.UserName + '\'').save(function (data) {
                 expect(data.length).toBe(0);


### PR DESCRIPTION
While looking into the API, I discovered that the `.ref` and `.removeRef` methods assume that the navigation property is always named the same as the entity set.

Say I have an API that has an entity set named `People` (just like the TripPinService example). Each of these people can have a set of people as their `Friends`.

It will always generate a request like this:
```
POST /odata/People('myusername')/People/$ref
{
    "@odata.id": "People('otherusername')"
}
```

When the request I really want is:
```
POST /odata/People('myusername')/Friends/$ref
{
    "@odata.id": "People('otherusername')"
}
```

The source in question can be seen here:
https://github.com/janhommes/o.js/blob/b153570c37e5646e1fb7261be01d6ef483938ea1/o.js#L396-L416

Specifically:
```js
resource.path.push({ resource: navPath, get: null });
```
and
```js
var newResource = parseUri(navPath);
```

This tells me that the code assumes `navPath` will be the same for the navigation property and the entity set name.

I'm more than willing to fix this, but I'd like some input on what change would be more appropriate for the API.
I have a couple of solutions in mind at the moment that would fix this:

1. Add another parameter to `.ref` and `.removeRef` that takes in the entity set name. You would then call the function like this:
```js
o('People(\'myusername\')').ref('Friends', 'People', 'otherusername')
```

2. Force the user to specify the navigation property name in the URL beforehand. In which case, the function call would look something like this:
```js
o('People(\'myusername\')/Friends').ref('People', 'otherusername')
```