### PR TITLE
WIP: Support for GET queries using `.ref`

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ o('http://services.odata.org/V4/OData/OData.svc/Products(1)').remove().save(func
 
 ### Reference:
 
+To retrieve a referenced object instead of the resource, use `ref`:
+
+```javascript
+o('http://services.odata.org/V4/OData/OData.svc/Products(1)').ref('Categories').get(function(data) {
+  console.log(data); // data contains the associated category instead of the product
+});
+```
+
 To add an reference to an other resource use `ref` (to remove it simply use `removeRef` the same way):
 
 ```javascript

--- a/o.js
+++ b/o.js
@@ -404,19 +404,21 @@
                 throwEx('You need to define a resource with the find() method to append an navigation property');
             }
             if (base.oConfig.version < 4) {
-                resource.method = 'POST';
                 resource.path.push('$links');
                 resource.path.push({ resource: navPath, get: null });
             }
             else {
-                resource.method = 'POST';
                 resource.path.push({ resource: navPath, get: null });
                 resource.path.push({ resource: '$ref', get: null });
             }
-            var newResource = parseUri(res || navPath);
-            newResource.path[newResource.path.length - 1].get = id;
-            var baseRes = buildQuery(newResource);
-            resource.data = { '@odata.id': baseRes };
+
+            if (id) {
+                resource.method = 'POST';
+                var newResource = parseUri(res || navPath);
+                newResource.path[newResource.path.length - 1].get = id;
+                var baseRes = buildQuery(newResource);
+                resource.data = { '@odata.id': baseRes };
+            }
             return (base);
         }
 


### PR DESCRIPTION
Originally requested by @be236 in #51 

Suggested API:
```js
o('Products(0)').ref('Categories').get(result => console.log(result.data));
```

Relevant part of the v4 spec:
```
11.2.7 Requesting Entity References
To request entity references in place of the actual entities, the client issues a GET request with /$ref appended to the resource path.
If the resource path does not identify an entity or a collection of entities, the service returns 404 Not Found.
If the resource path terminates on a collection, the response MUST be the format-specific representation of a collection of entity references pointing to the related entities. If no entities are related, the response is the format-specific representation of an empty collection.
If the resource path terminates on a single entity, the response MUST be the format-specific representation of an entity reference pointing to the related single entity. If the resource path terminates on a single entity and no such entity exists, the service returns either  204 No Content or 404 Not Found.
Example 61: collection with an entity reference for each Order related to the Product with ID=0

http://host/service/Products(0)/Orders/$ref
```
See: http://docs.oasis-open.org/odata/odata/v4.0/errata03/os/complete/part1-protocol/odata-v4.0-errata03-os-part1-protocol-complete.html#_Toc453752290

Relevant part of the v3 spec:
```
10.2.4. Requesting $links between Entities
To request the links (URLs) of related entities according to a particular relationship, the client issues a GET request.

The path of the request is /$links/ appended to the path of a the source entity’s request URL, followed by the name of the navigation property representing the relationship.

On success, the response body MUST contain the URL for each related entity, formatted as a either a single link, or a collection of links, depending on the cardinality of the relationship.

If the navigation property does not exist on the entity indicated by the request URL, the service SHOULD return 404 Not Found.

For example:

http://services.odata.org/OData/OData.svc/Products(0)/$links/Orders
Returns the URLs of each Order related to the Product with ID=0.
```
See: http://www.odata.org/documentation/odata-version-3-0/odata-version-3-0-core-protocol/