### PR TITLE
Use CRLF instead of LF in batch body

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Basic configuration is based on [RequestInit](https://developer.mozilla.org/en-U
 ```
 {
     batch: {
+      boundaryPrefix: "batch_",
       changsetBoundaryPrefix: "changset_",
       endpoint: "$batch",
       headers: new Headers({
@@ -121,7 +122,6 @@ Basic configuration is based on [RequestInit](https://developer.mozilla.org/en-U
       }),
       useChangset: false,
     },
-    boundaryPrefix: "batch_",
     credentials: "omit",
     fragment: "value",
     headers: new Headers({

--- a/src/__snapshots__/o.spec.ts.snap
+++ b/src/__snapshots__/o.spec.ts.snap
@@ -3,6 +3,7 @@
 exports[`initialize a new oHandler config should be default if not given 1`] = `
 Object {
   "batch": Object {
+    "boundaryPrefix": "batch_",
     "changsetBoundaryPrefix": "changset_",
     "endpoint": "$batch",
     "headers": Headers {
@@ -12,7 +13,6 @@ Object {
     },
     "useChangset": false,
   },
-  "boundaryPrefix": "batch_",
   "credentials": "omit",
   "fragment": "value",
   "headers": Headers {

--- a/src/o.ts
+++ b/src/o.ts
@@ -34,6 +34,7 @@ export function o(rootUrl: string | URL, config: OdataConfig | any = {}) {
   // set the default configuration values
   const defaultConfigValues = {
     batch: {
+      boundaryPrefix: "batch_",
       changsetBoundaryPrefix: "changset_",
       endpoint: "$batch",
       headers: new Headers({
@@ -41,7 +42,6 @@ export function o(rootUrl: string | URL, config: OdataConfig | any = {}) {
       }),
       useChangset: false
     },
-    boundaryPrefix: "batch_",
     credentials: "omit",
     fragment: "value",
     headers: new Headers({


### PR DESCRIPTION
May be related to #94.  Working with olingo v2 data source, discovered that code wasn't following spec and using LF instead of CRLF when building the batch request body. 