### PR TITLE
On batch changeset, include the content ids, status codes, and response bodies in the result

### DIFF
--- a/src/OBatch.ts
+++ b/src/OBatch.ts
@@ -67,13 +67,7 @@ export class OBatch {
       const data = await res.text();
       return this.parseResponse(data, res.headers.get("Content-Type"));
     } else {
-      // check if return is JSON
-      try {
-        const error = await res.json();
-        throw { res, error };
-      } catch (ex) {
-        throw typeof ex.error !== 'undefined' ? ex : res;
-      }
+      throw res;
     }
   }
 

--- a/src/o.spec.ts
+++ b/src/o.spec.ts
@@ -454,7 +454,7 @@ describe("Batching", () => {
     const data = await oHandler.get(resource1).get(resource2).batch();
     // expect
     expect(data.length).toBe(2);
-    expect(data[0].length).toBeDefined();
+    expect(data[0].body.length).toBeDefined();
   });
 
   test("Batch multiple GET requests and allow to add a query", async () => {
@@ -466,7 +466,7 @@ describe("Batching", () => {
       .get(resource2)
       .batch({ $top: 2 });
     // expect
-    expect(data[0].length).toBe(2);
+    expect(data[0].body.length).toBe(2);
   });
 
   test("Batch multiple GET requests and patch something", async () => {
@@ -480,8 +480,8 @@ describe("Batching", () => {
       .batch();
     // expect
     expect(data.length).toBe(3);
-    expect(data[1]).toBe(204);
-    expect(data[2].Name).toBe("New");
+    expect(data[1].status).toBe(204);
+    expect(data[2].body.Name).toBe("New");
   });
 
   test("Batch POST and PATCH with useChangeset=true", async () => {
@@ -502,8 +502,8 @@ describe("Batching", () => {
     const data = await request.batch();
     // expect
     expect(data.length).toBe(2);
-    expect(data[0].LastName).toBe(resouce1data.LastName);
-    expect(data[1]).toBe(204);
+    expect(data[0].body.LastName).toBe(resouce1data.LastName);
+    expect(data[1].status).toBe(204);
   });
 
   // Content ID seems to have a problem in the test implementation (or I don't get the right implementation)
@@ -525,7 +525,7 @@ describe("Batching", () => {
       .batch();
     // expect
     expect(result.length).toBe(3);
-    expect(result[1]).toBe(204);
-    expect(result[2].LastName).toBe("Bar");
+    expect(result[1].status).toBe(204);
+    expect(result[2].body.LastName).toBe("Bar");
   });
 });


### PR DESCRIPTION
On batch changeset, include the content ids, status codes, and response bodies in the result. These are important pieces of information for processing batch changeset responses. It also standardizes the response format rather than having different data types, one for just status code when no body is provided and another with the response body but no status code.

Also fix bug on batch error where response JSON body not included in the exception. In the try block {res, error} is being thrown which is immediately being caught in the catch block which throws only res so the error JSON body gets lost.