### PR TITLE
Add option to use custom applyQuery function.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "o.js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.3.0",
+      "name": "o.js",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "cross-fetch": "^3.0.6",
@@ -2679,8 +2680,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -3776,9 +3776,6 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
       "engines": {
         "node": ">=8"
       },
@@ -4558,7 +4555,6 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.5.0",
@@ -5870,9 +5866,6 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.6"
-      },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -7096,8 +7089,7 @@
       "dev": true,
       "dependencies": {
         "commander": "~2.9.0",
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0"
+        "source-map": "~0.5.1"
       },
       "bin": {
         "uglifyjs": "bin/uglifyjs"

--- a/src/OBatch.ts
+++ b/src/OBatch.ts
@@ -30,7 +30,7 @@ export class OBatch {
     }
 
     resources.forEach(
-      (req) => req.config.method === "GET" && req.applyQuery(query),
+      (req) => req.config.method === "GET" && req.applyQuery(query, config.applyQuery),
     );
     let contentId = 0;
     this.batchBody += resources.map((req) => {
@@ -43,12 +43,12 @@ export class OBatch {
         "",
         `${req.config.method} ${this.getRequestURL(req)} HTTP/1.1`,
         `${this.getHeaders(req)}`,
-        `${this.getBody(req)}`
+        `${this.getBody(req)}`,
       ].join(CRLF);
     }).join(`${CRLF}--${this.batchUid}`);
 
     this.batchBody += `${CRLF}--${this.batchUid}--${CRLF}`;
-    if(!changeset){
+    if (!changeset) {
       (this.batchConfig.headers as Headers).set(
         "Content-Type",
         `multipart/mixed;boundary=${this.batchUid}`,
@@ -133,7 +133,7 @@ export class OBatch {
         "",
         `Content-Type: multipart/mixed;boundary=${this.batchUid}`,
         "",
-        `--${this.batchUid}`
+        `--${this.batchUid}`,
       ].join(CRLF);
     } else if (changeRes.length > 0) {
       this.batchBody = `--${this.batchUid}`;
@@ -180,27 +180,27 @@ export class OBatch {
   }
 
   private getHeaders(req: ORequest): string {
-  // Request headers can be Headers | string[][] | Record<string, string>.
-  // A new Headers instance around them allows treatment of all three types
-  // to be the same. This also applies security last two could bypass.
-  const headers = new Headers(req.config.headers || undefined) as any;
-  // Convert each header to single string.
-  // Headers is iterable. Array.from is needed instead of Object.keys.
-  const mapped = Array.from(headers).map(([k, v]) => `${k}: ${v}`);
-  if (mapped.length) {
-    // Need to ensure a blank line between HEADERS and BODY. When there are
-    // headers, it must be added here. Otherwise blank is added in ctor.
-    mapped.push("");
-  }
-  return mapped.join(CRLF);
+    // Request headers can be Headers | string[][] | Record<string, string>.
+    // A new Headers instance around them allows treatment of all three types
+    // to be the same. This also applies security last two could bypass.
+    const headers = new Headers(req.config.headers || undefined) as any;
+    // Convert each header to single string.
+    // Headers is iterable. Array.from is needed instead of Object.keys.
+    const mapped = Array.from(headers).map(([k, v]) => `${k}: ${v}`);
+    if (mapped.length) {
+      // Need to ensure a blank line between HEADERS and BODY. When there are
+      // headers, it must be added here. Otherwise blank is added in ctor.
+      mapped.push("");
+    }
+    return mapped.join(CRLF);
   }
 
   private getRequestURL(req: ORequest): string {
-  let href = req.url.href;
-  if (this.batchConfig.batch.useRelativeURLs) {
-    // Strip away matching root from request.
-    href = href.replace((this.batchConfig.rootUrl as URL).href, "");
-  }
-  return href;
+    let href = req.url.href;
+    if (this.batchConfig.batch.useRelativeURLs) {
+      // Strip away matching root from request.
+      href = href.replace((this.batchConfig.rootUrl as URL).href, "");
+    }
+    return href;
   }
 }

--- a/src/OHandler.ts
+++ b/src/OHandler.ts
@@ -220,13 +220,13 @@ export class OHandler {
     if (this.pending > 1) {
       const result: Response[] = [];
       for (const req of this.requests) {
-        req.applyQuery({ ...this.config.query, ...query });
+        req.applyQuery({ ...this.config.query, ...query }, this.config.applyQuery);
         const request = await req.fetch;
         result.push(request);
       }
       return result;
     } else {
-      this.requests[0].applyQuery({ ...this.config.query, ...query });
+      this.requests[0].applyQuery({ ...this.config.query, ...query }, this.config.applyQuery);
       return [await this.requests[0].fetch];
     }
   }

--- a/src/ORequest.spec.ts
+++ b/src/ORequest.spec.ts
@@ -1,0 +1,30 @@
+import { OdataQuery } from "./OdataQuery";
+import { ORequest } from "./ORequest";
+
+describe("applyQuery", () => {
+  it('uses "application/x-www-form-urlencoded" encoding by default', () => {
+    expect(new ORequest(new URL("https://example.com"), {}).applyQuery({
+      $top: 4,
+      $filter: "foo eq bar or startsWith(foo, 'baz')",
+    }).url.href).toBe("https://example.com/?%24top=4&%24filter=foo+eq+bar+or+startsWith%28foo%2C+%27baz%27%29");
+  });
+
+  it("uses specifc applyQuery function", () => {
+    const encodeComponent =
+      (str: string) => encodeURIComponent(str)
+        .replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`);
+
+    // custom applyQuery will encode spaces in query parameters as "%20" instead of "+"
+    const applyQuery = (url: URL, query: OdataQuery) => {
+      url.search = Object.entries(query)
+        .map(([key, value]) => `${encodeComponent(key)}=${encodeComponent(value)}`).join("&");
+      return url;
+    };
+
+    expect(new ORequest(new URL("https://example.com"), {}).applyQuery({
+      $top: 4,
+      $filter: "foo eq bar or startsWith(foo, 'baz')",
+    }, applyQuery).url.href)
+      .toBe("https://example.com/?%24top=4&%24filter=foo%20eq%20bar%20or%20startsWith%28foo%2C%20%27baz%27%29");
+  });
+});

--- a/src/ORequest.ts
+++ b/src/ORequest.ts
@@ -1,4 +1,19 @@
+import { ApplyQuery } from "./OdataConfig";
 import { OdataQuery } from "./OdataQuery";
+
+const defaultApplyQuery: ApplyQuery = (url, query) => {
+  for (const key in query) {
+    if (query.hasOwnProperty(key)) {
+      if (url.searchParams.get(key)) {
+        url.searchParams.set(key, query[key]);
+      } else {
+        url.searchParams.append(key, query[key]);
+      }
+    }
+  }
+
+  return url;
+};
 
 export class ORequest {
   public url: URL;
@@ -16,15 +31,8 @@ export class ORequest {
     return fetch(req, this.config);
   }
 
-  public applyQuery(query?: OdataQuery) {
-    for (const key in query) {
-      if (query.hasOwnProperty(key)) {
-        if (this.url.searchParams.get(key)) {
-          this.url.searchParams.set(key, query[key]);
-        } else {
-          this.url.searchParams.append(key, query[key]);
-        }
-      }
-    }
+  public applyQuery(query: OdataQuery, applyQueryFn = defaultApplyQuery) {
+    applyQueryFn(this.url, query);
+    return this;
   }
 }

--- a/src/OdataConfig.ts
+++ b/src/OdataConfig.ts
@@ -1,5 +1,5 @@
-import { OHandler } from "./OHandler";
 import { OdataQuery } from "./OdataQuery";
+import { OHandler } from "./OHandler";
 
 export interface OdataBatchConfig {
   endpoint?: string;
@@ -12,6 +12,8 @@ export interface OdataBatchConfig {
    */
   useRelativeURLs: boolean;
 }
+
+export type ApplyQuery = (url: URL, query: OdataQuery) => URL;
 
 export type OdataConfig = RequestInit & {
   /**
@@ -54,4 +56,9 @@ export type OdataConfig = RequestInit & {
    * A function which is called when a request has a error
    */
   onError: (oHandler: OHandler, res: Response) => null;
+
+  /**
+   * An option to apply the query parameters to a URL in a custom way
+   */
+  applyQuery?: ApplyQuery;
 };


### PR DESCRIPTION
Include ability to specify a custom function to apply query parameters to a URL. The reason this is necessary is described in https://github.com/janhommes/o.js/issues/129#issue-1179733199

This does not include an alternative to the default - I leave it to the (repo) author to decide if we want to change the default to something more widely accepted. I have only introduced an escape hatch since currently there is no way to modify the query params other than monkey patching `fetch` which I had to do to make this work with Apache Olingo.