### PR TITLE
fix: use response.ok to assert a successful response

### DIFF
--- a/src/OBatch.ts
+++ b/src/OBatch.ts
@@ -63,7 +63,7 @@ export class OBatch {
       method: "POST",
     });
     const res: Response = await req.fetch;
-    if (res.status === 200) {
+    if (res.ok) {
       const data = await res.text();
       return this.parseResponse(data, res.headers.get("Content-Type"));
     } else {


### PR DESCRIPTION
# Why?
Successful batch requests were throwing on my end since the server I connect to responds with 202.

# What?
Asserts successful responses with `Response.ok` instead of checking the status code.